### PR TITLE
svi

### DIFF
--- a/ethernet/bridge.go
+++ b/ethernet/bridge.go
@@ -5,41 +5,52 @@ package ethernet
 
 import (
 	"fmt"
+	"net"
 
 	"github.com/platinasystems/vnet"
 	"github.com/platinasystems/vnet/internal/dbgvnet"
 	"github.com/platinasystems/xeth"
 )
 
-// bridge member is indexed by portvid and its master's stag
-// a port can only appear with one ctag (or untagged) per master
-// stored directly in map since it's small struct
-
-type bridgeMember struct {
-	Ifindex int32
-	Ctag    uint16
+// in case we need bridge attributes beyond what's available in PortEntry
+type bridgeEntry struct {
+	port          *vnet.PortEntry   // bridge contains port which is network interface (port has stag and Net/netns)
+	_macToIfindex map[Address]int32 // DA to ifindex of bridge member (FIXME replaced by map in fe1, remove when fdb pushed to linux)
 }
 
-type Bridge struct {
-	port         *vnet.PortEntry         // bridge contains port which is network interface (port has stag and Net/netns)
-	members      map[uint16]bridgeMember // bridge config, indexed by portvid
-	macToIfindex map[Address]int32       // learned MACs per member: DA maps to ifindex of bridge member
+// pipe_port can only appear with one ctag (or eventually untagged) per master
+type fdbBridgeMember struct {
+	stag      uint16
+	pipe_port uint16
 }
 
-func (br *Bridge) String() (dump string) {
-	dump = fmt.Sprintf("%v, si %v, stag %v, addr %v\n", br.port.Ifname, vnet.SiByIfindex[br.port.Ifindex], br.port.Stag, br.port.Addr)
-	dump += fmt.Sprintf("members:\n")
-	for portvid, brm := range br.members {
-		be := vnet.PortsByIndex[brm.Ifindex]
-		if be != nil {
-			dump += fmt.Sprintf(" %-12v", be.Ifname)
-		}
-		dump += fmt.Sprintf(" portvid:%v->ifindex:%v,ctag:%v", portvid, brm.Ifindex, brm.Ctag)
-		dump += fmt.Sprintf("\n")
-	}
-	dump += fmt.Sprintf("macToIfindex:\n")
-	for addr, ifindex := range br.macToIfindex {
-		dump += fmt.Sprintf(" %v->%v", addr.String(), ifindex)
+// FIXME ifindex for bridge is not global, must include netns
+type fdbBridgeIndex struct {
+	bridge int32
+	member int32
+	port   int32
+}
+
+// map TH fdb stag/pipe_port to linux netns/ifindex for bridge and bridge-member
+// fe1 reports learning on fdbBrm, convert to fdbBri when reporting to linux
+var fdbBrmToBri = map[fdbBridgeMember]fdbBridgeIndex{}
+
+// learned by pipe_port, lookup bridge member via portvid
+type PortFdbInfo struct {
+	PipePort uint16
+	PortVid  uint16
+}
+
+var PipePortByPortVid map[uint16]uint16 // FIXME remove, not needed for learning lookup
+
+var bridgeByStag map[uint16]*bridgeEntry
+
+func (br *bridgeEntry) String() (dump string) {
+	dump = fmt.Sprintf("%v, si %v, stag %v, addr %v\n",
+		br.port.Ifname, vnet.SiByIfindex[br.port.Ifindex], br.port.Stag, br.port.StationAddr)
+	dump += fmt.Sprintf("_macToIfindex: %v entries\n", len(br._macToIfindex))
+	for addr, ifindex := range br._macToIfindex {
+		dump += fmt.Sprintf(" %v learned on ifindex %v", addr.String(), ifindex)
 		be := vnet.PortsByIndex[ifindex]
 		if be != nil {
 			dump += fmt.Sprintf(" %v", be.Ifname)
@@ -49,31 +60,41 @@ func (br *Bridge) String() (dump string) {
 	return
 }
 
-// return si for XETH_DEVTYPE_PORT egress to reach da
-func (br *Bridge) LookupSiCtag(da Address) (si vnet.Si, ctag uint16) {
-	i := br.macToIfindex[da]
-
-	if i == 0 {
-		dbgvnet.Bridge.Logf("br dest %+v @unknown", da)
-		si = vnet.SiNil
-	} else {
-		brm := vnet.PortsByIndex[i]
-		si = vnet.SiByIfindex[i]
-		ctag = brm.Ctag
-		dbgvnet.Bridge.Logf("br dest %+v ifindex %v, ctag %v, stag %v, si %v, type %v",
-			da, i, brm.Stag, brm.Ctag, si, brm.Devtype)
+// number of bridge members on a port
+func numBrmOnPort(ifindex int32) (brgMems uint8) {
+	for _, bri := range fdbBrmToBri {
+		if bri.port == ifindex {
+			brgMems++
+		}
 	}
 	return
 }
 
-// learned by pipe_port, lookup bridge member via portvid
-type PortFdbInfo struct {
-	PipePort uint16
-	PortVid  uint16
-}
+// return si for XETH_DEVTYPE_PORT egress to reach da
+func (br *bridgeEntry) LookupSiCtag(da Address, v *vnet.Vnet) (si vnet.Si, ctag uint16) {
+	var fdbBri fdbBridgeIndex
+	var fdbBrm fdbBridgeMember
+	var err error
 
-var BridgeByStag map[uint16]*Bridge
-var PipePortByPortVid map[uint16]uint16 // FIXME remove, not needed for learning lookup
+	hw_addr := make(net.HardwareAddr, 6)
+	hw_addr = da[:]
+
+	fdbBrm.stag = br.port.Stag
+	fdbBrm.pipe_port, err = v.BridgeMemberLookup(br.port.Stag, hw_addr)
+	fdbBri = fdbBrmToBri[fdbBrm]
+	dbgvnet.Bridge.Logf("br fe1 lookup[%v] %+v=>%+v, err %v", hw_addr, fdbBrm, fdbBri, err)
+
+	if fdbBri.member == 0 {
+		si = vnet.SiNil
+	} else {
+		brm := vnet.PortsByIndex[fdbBri.member]
+		si = vnet.SiByIfindex[fdbBri.member]
+		ctag = brm.Ctag
+		dbgvnet.Bridge.Logf("br stag %v, ctag %v, si %v, type %v",
+			brm.Stag, ctag, si, brm.Devtype)
+	}
+	return
+}
 
 // called from fe1 to init map so vnet can call br api by pipe-port
 func (m *Main) SetPortMap(fi []PortFdbInfo) {
@@ -89,103 +110,91 @@ func (m *Main) SetPortMap(fi []PortFdbInfo) {
 	dbgvnet.Bridge.Logf("%+v", PipePortByPortVid)
 }
 
-type fdbBridgeMember struct {
-	stag      uint16
-	pipe_port uint16
-}
-
-// FIXME ifindex for bridge is not global, must include netns
-type fdbBridgeIndex struct {
-	bridge int32
-	member int32
-}
-
-// map TH fdb stag/pipe_port to linux netns/ifindex for bridge and bridge-member
-var fdbBrmToIndex = map[fdbBridgeMember]fdbBridgeIndex{}
-
-// indexed by portvid/stag in map
-func BridgeMemberAdd(br *Bridge, brm *vnet.PortEntry) {
-	entry, found := br.members[brm.PortVid]
-	if !found {
-		entry = bridgeMember{}
-	}
-	entry.Ctag = brm.Ctag
-	entry.Ifindex = brm.Ifindex
-	br.members[brm.PortVid] = entry
-	brm.Stag = br.port.Stag
-	dbgvnet.Bridge.Logf("stag %v, portvid %v, %+v",
-		br.port.Stag, brm.PortVid, br.members)
-}
-
 // add/remove port from bridge, no change to netns
 // update fdb map of stag/pipeport to ifindex of bridge member
 func ProcessChangeUpper(msg *xeth.MsgChangeUpper, action vnet.ActionType, v *vnet.Vnet) (err error) {
-	var brm fdbBridgeMember
-	var bridx fdbBridgeIndex
+	var fdbBrm fdbBridgeMember
 
 	switch action {
 	case vnet.PostReadyVnetd:
 	case vnet.Dynamic:
 	default:
-		err = dbgvnet.Bridge.Logf("error: unexpected action: %v", action)
+		err = dbgvnet.Bridge.Logf("error: unexpected action: %v, %+v", action, msg)
 		return
 	}
 
-	newBe := vnet.GetPortByIndex(msg.Upper)
-	if newBe == nil {
+	portUpper := vnet.GetPortByIndex(msg.Upper) // port contained by bridge
+	if portUpper == nil {
 		err = dbgvnet.Bridge.Logf("upper %v, port not found", msg.Upper)
 		return
+	} else if portUpper.Devtype != xeth.XETH_DEVTYPE_LINUX_BRIDGE {
+		return
 	}
-	newBr := BridgeByStag[newBe.Stag]
-	if newBr == nil {
+
+	brUpper := bridgeByStag[portUpper.Stag]
+	if brUpper == nil {
 		err = dbgvnet.Bridge.Logf("upper %v, br not found", msg.Upper)
 		return
 	}
 
-	brPort := vnet.GetPortByIndex(msg.Lower)
-	if brPort == nil {
+	portLower := vnet.GetPortByIndex(msg.Lower)
+	if portLower == nil {
 		err = dbgvnet.Bridge.Logf("lower %v, not found", msg.Lower)
 		return
 	}
-	if brPort.Devtype != xeth.XETH_DEVTYPE_LINUX_VLAN &&
-		brPort.Devtype != xeth.XETH_DEVTYPE_LINUX_VLAN_BRIDGE_PORT {
+	if portLower.Devtype != xeth.XETH_DEVTYPE_LINUX_VLAN &&
+		portLower.Devtype != xeth.XETH_DEVTYPE_LINUX_VLAN_BRIDGE_PORT {
 		dbgvnet.Bridge.Logf("lower[%v] type=%v not vlan, not supported as brm",
 			msg.Lower,
-			brPort.Devtype)
+			portLower.Devtype)
 		return
 	}
 
 	if msg.Linking == 0 {
-		if brPort.Stag != 0 {
-			oldBr := BridgeByStag[brPort.Stag]
-			delete(oldBr.members, brPort.PortVid)
-			dbgvnet.Bridge.Logf("brm del, stag %v, portvid %v, %+v",
-				oldBr.port.Stag, brPort.PortVid, oldBr.members)
-
-			brm.stag = brPort.Stag
-			brm.pipe_port = PipePortByPortVid[brPort.PortVid]
-			delete(fdbBrmToIndex, brm)
-			v.BridgeMemberAddDelHook(vnet.SiByIfindex[msg.Upper], brPort.Stag,
-				vnet.SiByIfindex[msg.Lower],
-				PipePortByPortVid[brPort.PortVid], brPort.Ctag, false)
+		if portLower.Stag != 0 {
+			fdbBrm.stag = portLower.Stag
+			fdbBrm.pipe_port = PipePortByPortVid[portLower.PortVid]
+			if fdbBri, ok := fdbBrmToBri[fdbBrm]; ok {
+				dbgvnet.Bridge.Logf("brm del %+v, %+v, br.stag:%v, portvid:%v",
+					fdbBrm, fdbBri, brUpper.port.Stag, portLower.PortVid)
+				delete(fdbBrmToBri, fdbBrm)
+				v.BridgeMemberAddDelHook(fdbBrm.stag, vnet.SiByIfindex[fdbBri.member],
+					fdbBrm.pipe_port, portLower.Ctag, false, numBrmOnPort(fdbBri.port))
+				portLower.Stag = 0
+				portLower.Devtype = xeth.XETH_DEVTYPE_LINUX_VLAN
+			} else {
+				dbgvnet.Bridge.Logf("fdbBri not found %+v", fdbBrm)
+			}
 		}
 	} else {
-		brm.stag = newBr.port.Stag
-		brm.pipe_port = PipePortByPortVid[brPort.PortVid]
-		bridx.bridge = msg.Upper
-		bridx.member = msg.Lower
-		fdbBrmToIndex[brm] = bridx
+		fdbBrm.stag = brUpper.port.Stag
+		fdbBrm.pipe_port = PipePortByPortVid[portLower.PortVid]
 
-		BridgeMemberAdd(newBr, brPort)
-		v.BridgeMemberAddDelHook(vnet.SiByIfindex[msg.Upper], newBr.port.Stag,
-			vnet.SiByIfindex[msg.Lower],
-			PipePortByPortVid[brPort.PortVid], brPort.Ctag, true)
+		fdbBri, ok := fdbBrmToBri[fdbBrm]
+		if ok {
+			dbgvnet.Bridge.Logf("brm add, REPLACE %+v %+v", fdbBrm, fdbBri) // FIXME cleanup fe1 if this ever happens
+			delete(fdbBrmToBri, fdbBrm)
+		}
+		fdbBri.bridge = msg.Upper
+		fdbBri.member = msg.Lower
+		fdbBri.port = portLower.Iflinkindex
+
+		dbgvnet.Bridge.Logf("brm add %+v, %+v, br.stag=%v, portvid %v",
+			fdbBrm, fdbBri, brUpper.port.Stag, portLower.PortVid)
+		fdbBrmToBri[fdbBrm] = fdbBri
+
+		// indexed by portvid/stag in map
+		portLower.Stag = brUpper.port.Stag
+
+		v.BridgeMemberAddDelHook(fdbBrm.stag, vnet.SiByIfindex[fdbBri.member],
+			fdbBrm.pipe_port, portLower.Ctag, true, numBrmOnPort(fdbBri.port))
+		portLower.Devtype = xeth.XETH_DEVTYPE_LINUX_VLAN_BRIDGE_PORT
 	}
 	return
 }
 
-func GetBridgeBySi(si vnet.Si) (br *Bridge) {
-	for _, b := range BridgeByStag {
+func GetBridgeBySi(si vnet.Si) (br *bridgeEntry) {
+	for _, b := range bridgeByStag {
 		bsi := vnet.SiByIfindex[b.port.Ifindex]
 		if bsi == si {
 			br = b
@@ -200,15 +209,14 @@ func GetBridgeBySi(si vnet.Si) (br *Bridge) {
 // stag may change, so that map must be refreshed
 func SetBridge(stag uint16, ifname string) *vnet.PortEntry {
 	dbgvnet.Bridge.Logf("set br %v %v", stag, ifname)
-	if BridgeByStag == nil {
-		BridgeByStag = make(map[uint16]*Bridge)
+	if bridgeByStag == nil {
+		bridgeByStag = make(map[uint16]*bridgeEntry)
 	}
-	br := BridgeByStag[stag]
+	br := bridgeByStag[stag]
 	if br == nil {
-		br = new(Bridge)
-		br.members = make(map[uint16]bridgeMember)
-		br.macToIfindex = make(map[Address]int32)
-		BridgeByStag[stag] = br
+		br = new(bridgeEntry)
+		br._macToIfindex = make(map[Address]int32)
+		bridgeByStag[stag] = br
 	}
 	pe := vnet.SetPort(ifname)
 	if pe.Stag != 0 {
@@ -217,53 +225,44 @@ func SetBridge(stag uint16, ifname string) *vnet.PortEntry {
 		}
 	}
 	pe.Stag = stag
-	pe.Devtype = xeth.XETH_DEVTYPE_LINUX_BRIDGE
-	pe.Portindex = -1
-	pe.Subportindex = -1
-
 	br.port = pe
 	return pe
 }
 
 func UnsetBridge(stag uint16) {
-	br := BridgeByStag[stag]
+	br := bridgeByStag[stag]
 	if br != nil {
-		dbgvnet.Bridge.Logf("delete bridge %v, stag %v", br.port.Ifname, br.port.Stag)
-		delete(BridgeByStag, br.port.Stag)
+		dbgvnet.Bridge.Logf("delete br %v, stag %v/%v", br.port.Ifname, stag, br.port.Stag)
 		vnet.UnsetPort(br.port.Ifname)
+		br.port = nil
+		delete(bridgeByStag, stag)
 	}
 }
 
+// push fdb updates to linux
 func goSviFromFe() {
-	var brm fdbBridgeMember
-	var bridx fdbBridgeIndex
+	var fdbBrm fdbBridgeMember
+	var fdbBri fdbBridgeIndex
 
 	for msg := range vnet.SviFromFeCh {
-		dbgvnet.Bridge.Logf("Got message from Fe - %+v", msg)
-		switch {
-		case msg.MsgId == vnet.MSG_SVI_FDB_ADD:
-			brm.stag = msg.Stag
-			brm.pipe_port = msg.PipePort
-			bridx = fdbBrmToIndex[brm]
-
-			br := BridgeByStag[msg.Stag]
-			if br != nil {
-				// add entry to fdb so we can lookup L3 interface by bridge/mac
-				br.macToIfindex[msg.Addr] = bridx.member
-				dbgvnet.Bridge.Logf("br fdb add bridge stag %v, mac %v -> brm ifindex %v",
-					msg.Stag,
-					msg.Addr,
-					bridx.member)
+		br := bridgeByStag[msg.Stag]
+		if br == nil {
+			dbgvnet.Bridge.Logf("br not found %+v", msg)
+		} else {
+			switch {
+			case msg.MsgId == vnet.MSG_SVI_FDB_ADD:
+				fdbBrm.stag = msg.Stag
+				fdbBrm.pipe_port = msg.PipePort
+				fdbBri = fdbBrmToBri[fdbBrm]
+				br._macToIfindex[msg.Addr] = fdbBri.member
+			case msg.MsgId == vnet.MSG_SVI_FDB_DELETE:
+				delete(br._macToIfindex, msg.Addr)
 			}
-		case msg.MsgId == vnet.MSG_SVI_FDB_DELETE:
-			dbgvnet.Bridge.Logf("br fdb del bridge stag %v, mac %+v",
-				msg.Stag,
-				msg.Addr)
 		}
 	}
 }
 
-// l2-mod-fifo learning is posted async from fe1 to vnet
+// l2-mod-fifo learning, aging, and flush is posted async from fe1 to vnet
 func StartFromFeReceivers() {
 	if vnet.SviFromFeCh == nil {
 		vnet.SviFromFeCh = make(chan vnet.FromFeMsg, 32)

--- a/ethernet/cli.go
+++ b/ethernet/cli.go
@@ -104,12 +104,42 @@ func (m *Main) showIpNeighbor(c cli.Commander, w cli.Writer, in *cli.Input) (err
 	return
 }
 
+func (m *Main) fdbBridgeShow(c cli.Commander, w cli.Writer, in *cli.Input) (err error) {
+	var brmPerPort map[int32]uint32
+
+	brmPerPort = make(map[int32]uint32)
+
+	for stag, br := range bridgeByStag {
+		fmt.Fprintf(w, "bridgeByStag[%v] %s\n", stag, br)
+	}
+	fmt.Fprintf(w, "fdbBrmToBri\n")
+	for brm, bri := range fdbBrmToBri {
+		if count, ok := brmPerPort[bri.port]; ok {
+			brmPerPort[bri.port] = count + 1
+		} else {
+			brmPerPort[bri.port] = 1
+		}
+		fmt.Fprintf(w, "%+v %+v\n", brm, bri)
+	}
+	fmt.Fprintf(w, "brmPerPort\n")
+	for port, count := range brmPerPort {
+		fmt.Fprintf(w, "port %v, count %v\n", port, count)
+	}
+
+	return
+}
+
 func (m *Main) cliInit(v *vnet.Vnet) {
 	cmds := [...]cli.Command{
 		cli.Command{
 			Name:      "show neighbor",
 			ShortHelp: "show neighbors",
 			Action:    m.showIpNeighbor,
+		},
+		cli.Command{
+			Name:      "show bridge",
+			ShortHelp: "help",
+			Action:    m.fdbBridgeShow,
 		},
 	}
 	for i := range cmds {

--- a/ethernet/interface.go
+++ b/ethernet/interface.go
@@ -332,7 +332,7 @@ type rwHeader struct {
 	vlan [2]VlanHeader
 }
 
-func (br *Bridge) SetRewrite(v *vnet.Vnet, rw *vnet.Rewrite, packetType vnet.PacketType, da []byte, ctag uint16) {
+func (br *bridgeEntry) SetRewrite(v *vnet.Vnet, rw *vnet.Rewrite, packetType vnet.PacketType, da []byte, ctag uint16) {
 	var h rwHeader
 
 	t := rewriteTypeMap[packetType].FromHost()
@@ -348,7 +348,7 @@ func (br *Bridge) SetRewrite(v *vnet.Vnet, rw *vnet.Rewrite, packetType vnet.Pac
 	} else {
 		h.Dst = BroadcastAddr
 	}
-	copy(h.Src[:], br.port.Addr[:])
+	copy(h.Src[:], br.port.StationAddr[:])
 	dbgvnet.Bridge.Logf("br rewrite hdr=%+v", h)
 	rw.ResetData()
 	rw.AddData(unsafe.Pointer(&h), size)

--- a/ethernet/neighbor.go
+++ b/ethernet/neighbor.go
@@ -60,7 +60,7 @@ func (m *ipNeighborMain) AddDelIpNeighbor(im *ip.Main, n *IpNeighbor, isDel bool
 	var rwSi vnet.Si
 	var isBridge bool
 	var ctag, stag uint16
-	var br *Bridge
+	var br *bridgeEntry
 
 	ai = ip.AdjNil
 	nf := &m.ipNeighborFamilies[im.Family]
@@ -74,7 +74,7 @@ func (m *ipNeighborMain) AddDelIpNeighbor(im *ip.Main, n *IpNeighbor, isDel bool
 
 		// rewrite si port is bridge member
 		// si passed to fe1/fib install_adj() via rewrite is the bridge member to reach DA
-		rwSi, ctag = br.LookupSiCtag(n.Ethernet)
+		rwSi, ctag = br.LookupSiCtag(n.Ethernet, m.v)
 		if rwSi == vnet.SiNil {
 			dbgvnet.Adj.Logf("DA %v unresolved for br %v", n.Ethernet, br.port.Stag)
 			// if unknown, enqueue for later  FIXME

--- a/ip4/fib.go
+++ b/ip4/fib.go
@@ -1488,8 +1488,8 @@ func (m *Main) swIfAddDel(v *vnet.Vnet, si vnet.Si, isUp bool) (err error) {
 		return
 	}
 	f := m.fibBySi(si)
-	dbgvnet.Adj.Logf("clean up %v %v\n",
-		f.index.Name(&m.Main), si.Name(v))
+	dbgvnet.Adj.Logf("clean up %v %v %v up=%v",
+		f.index.Name(&m.Main), si, si.Name(v), isUp)
 	mp := &f.glean
 	mp_string := "glean"
 	for _, local := range [2]bool{false, true} {

--- a/node.go
+++ b/node.go
@@ -281,6 +281,7 @@ type Vnet struct {
 	packageMain
 	BridgeAddDelHook       BridgeAddDelHook_t
 	BridgeMemberAddDelHook BridgeMemberAddDelHook_t
+	BridgeMemberLookup     BridgeMemberLookup_t
 }
 
 func (v *Vnet) GetLoop() *loop.Loop { return &v.loop }


### PR DESCRIPTION
LookupSiCtag(): fe1 BridgeMemberLookup() for serialized sync/lookup
remove Si from BridgeMemberAddDelHook()
net.HardwareAddr for mac addr, and copy from param
derive puntIndex from xeth msg for port and br
delete bridge and vlan-intf on unreg event
fdbPortShow(): add maps to 'vnet show ports'
fdbBrmToBri: map bridge member to ifindex of bridge and member

Signed-off-by: Ron Taylor <rtaylor@platinasystems.com>